### PR TITLE
Include toolbox.json for chainloader instead of Fizeau sysmodule in chainloader release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(DIST_CHL_TARGET): | all
 
 	@mkdir -p $(OUT)/atmosphere/contents/$(FZ_CHL_TID)/flags
 	@cp chainloader/out/Fizeau-chl.nsp $(OUT)/atmosphere/contents/$(FZ_CHL_TID)/exefs.nsp
-	@cp chainloader/toolbox.json $(OUT)/atmosphere/contents/$(FZ_TID)/toolbox.json
+	@cp chainloader/toolbox.json $(OUT)/atmosphere/contents/$(FZ_CHL_TID)/toolbox.json
 	@touch $(OUT)/atmosphere/contents/$(FZ_CHL_TID)/flags/boot2.flag
 
 	@7z a $@ ./$(OUT)/atmosphere ./$(OUT)/config ./$(OUT)/switch >/dev/null

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ $(DIST_CHL_TARGET): | all
 
 	@mkdir -p $(OUT)/atmosphere/contents/$(FZ_TID)
 	@cp sysmodule/out/Fizeau.nsp $(OUT)/atmosphere/contents/$(FZ_TID)/exefs.nsp
-	@cp sysmodule/toolbox.json $(OUT)/atmosphere/contents/$(FZ_TID)/toolbox.json
 
 	@mkdir -p $(OUT)/atmosphere/contents/$(FZ_CHL_TID)/flags
 	@cp chainloader/out/Fizeau-chl.nsp $(OUT)/atmosphere/contents/$(FZ_CHL_TID)/exefs.nsp
+	@cp chainloader/toolbox.json $(OUT)/atmosphere/contents/$(FZ_TID)/toolbox.json
 	@touch $(OUT)/atmosphere/contents/$(FZ_CHL_TID)/flags/boot2.flag
 
 	@7z a $@ ./$(OUT)/atmosphere ./$(OUT)/config ./$(OUT)/switch >/dev/null

--- a/chainloader/toolbox.json
+++ b/chainloader/toolbox.json
@@ -1,0 +1,5 @@
+{
+    "name"  : "Fizeau chainloader",
+    "tid"   : "010000000000CF12",
+    "requires_reboot": true
+}


### PR DESCRIPTION
Regarding https://github.com/averne/Fizeau/issues/36

You closed it so I think you may have missed my original suggestion that when using the chainloader release managing the boot2.flag for the chainloader would be more important than knowing if the Fizeau sysmodule is running.